### PR TITLE
Add Robust Links

### DIFF
--- a/404.go
+++ b/404.go
@@ -6,7 +6,7 @@ const fourfour = `<!DOCTYPE html>
 	<meta charset="utf-8">
 	<title>httpreserve | 404 | page not found</title>
 
-	<link id="favicon" rel="icon" type="image/x-icon" 
+	<link id="favicon" rel="icon" type="image/x-icon"
 	href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABm
 	JLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA
 	B3RJTUUH4QMZAiAVgKAUZQAAAGlJREFUWMPt1jkSgDAMQ9GYk/
@@ -30,7 +30,7 @@ const fourfour = `<!DOCTYPE html>
 
       /*use push to position footer more usefully on screen if necessary*/
       div.push { height: 340px; min-height: 340px; }
-      
+
       div.footer { height: 50px; margin: 0 auto ; width:200px; text-align: center; }
 	</style>
 
@@ -40,39 +40,37 @@ const fourfour = `<!DOCTYPE html>
 	<div class="layout">
 	<p>
 	<center>
-		<figure>
-		  	<figcaption>httpreserve</figcaption>
-			<img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmc
-			vMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIHZpZXdCb3g9IjAgMCA4IDgiPg0KIC
-			A8cGF0aCBkPSJNMCAwdjFoOHYtMWgtOHptNCAybC0zIDNoMnYzaDJ2LTNoMmwtMy0zeiIgLz4NCjwvc3ZnPg==" 
-			width="50px" height="50px" alt="httpreserve"/>
-		</figure>
+            <figure>
+                <figcaption style="font-family: helvetica; arial, verdana; margin-bottom: 8px"><h1>httpreserve</h1></figcaption>
+                <img src=" ` + httpreserveImage + `"
+                width="80px" height="80px" alt="httpreserve"/>
+            </figure>
 	</center>
-	</p>   
+	</p>
 	<center>
 	<h4>404 | Page Not Found</h4>
 	<br/>
 	<p>
-	I'm sorry, the page you requested cannot be found. It's likely not your fault 
+	I'm sorry, the page you requested cannot be found. It's likely not your fault
 	though and I'll do what I can to fix the situation.
 	<br/><br/>
 	Please visit <a href="https://github.com/httpreserve/httpreserve/issues">GitHub Issues</a>
-	to log an issue. 
+	to log an issue.
 	<br/><br/>
 	This project is designed to help us look at web archiving from the inside out
 	<br/>
-	and to begin fixing the problem of broken links in documentary heritage. 
+	and to begin fixing the problem of broken links in documentary heritage.
 	<br/><br/>
-	If you'd like more information on the impact of broken links please watch this 
-	YouTube video from one of my colleagues in Melbourne. 
+	If you'd like more information on the impact of broken links please watch this
+	YouTube video from one of my colleagues in Melbourne.
 	<a href="https://www.youtube.com/watch?v=94JyVSFk8-0">Nicola Laurent</a>
 	<br>
 	at <a href="https://twitter.com/hashtag/asalinks?f=tweets&vertical=default&lang=en">#ASALinks</a>
 	<br/><br/>
 	Check out the rest of my work on <a href="http://github.com/httpreserve">GitHub.com</a>
 	<br/><br/>
-	Other background to this work 
-	<a href="https://www.youtube.com/watch?v=Ked9GRmKlRw">Binary Trees: Automatically Identifying the links between born digital records.</a>	
+	Other background to this work
+	<a href="https://www.youtube.com/watch?v=Ked9GRmKlRw">Binary Trees: Automatically Identifying the links between born digital records.</a>
 	<br/>
 	</p>
 	</center>
@@ -82,8 +80,8 @@ const fourfour = `<!DOCTYPE html>
 	A project by <a href="https://twitter.com/beet_keeper" alt="@beet_keeper on Twitter">@beet_keeper</a>
 	<br/>
 	On GitHub: <a href="https://github.com/exponential-decay/httpreserve" alt="httpreserve on GitHub">httpreserve</a>
-	</div>      
+	</div>
 </div>
 </body>
-</html> 
+</html>
 `

--- a/defaultserverpages.go
+++ b/defaultserverpages.go
@@ -202,7 +202,7 @@ var httpreservePages = `
            <input class="button" type="submit" value="httpreserve">
         </form>
         <br/><br/>
-        <pre class="analysis" id="httpreserve-analysis"></div>
+        <pre class="analysis" id="httpreserve-analysis"/></div>
         </p>
         <div>
         <center>

--- a/httpreservehandler.go
+++ b/httpreservehandler.go
@@ -133,7 +133,7 @@ func handleSubmitToInternetArchive(w http.ResponseWriter, r *http.Request) {
 
 // retrieve linkstats from httpreserve
 func retrieveLinkStats(link string, fname string) string {
-	ls, _ := GenerateLinkStats(link, fname, true)
+	ls, _ := GenerateLinkStatsEncoded(link, fname, true)
 	js := MakeLinkStatsJSON(ls)
 	return js
 }

--- a/httpreservestructs.go
+++ b/httpreservestructs.go
@@ -19,14 +19,16 @@ type LinkStats struct {
 	ResponseText                string
 	SourceURL                   string // URL requested by the caller
 	ScreenShot                  string // HREF to screenshot
-	InternetArchiveLinkEarliest string // Earliest link in Internet Archive
+	InternetArchiveLinkEarliest string `json:"InternetArchiveLinkEarliest,omitempty"`
 	InternetArchiveEarliestDate string `json:"InternetArchiveEarliestDate,omitempty"`
 	InternetArchiveLinkLatest   string
 	InternetArchiveLatestDate   string `json:"InternetArchiveLatestDate,omitempty"`
 	InternetArchiveSaveLink     string // Link to use to save from the Internet
 	InternetArchiveResponseCode int
 	InternetArchiveResponseText string
-	Archived                    bool // Has the Internet Archive saved the page or not?
+	RobustLinkEarliest          string `json:"RobustLinkEarliest,omitempty"` // A robust hyperlink snippet linking to a live url and a memento version
+	RobustLinkLatest            string `json:"RobustLinkLatest,omitempty"`   // A robust hyperlink snippet linking to a live url and a memento version
+	Archived                    bool   // Has the Internet Archive saved the page or not?
 	Error                       bool
 	ErrorMessage                string
 	StatsCreationTime           string

--- a/robustify.go
+++ b/robustify.go
@@ -1,0 +1,115 @@
+package httpreserve
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// formatRobustDate returns a Robust formatted date for a given value.
+func formatRobustDate(inputDate string) string {
+	const fourteenDigitDateFormat = "20060102150405"
+	outputDate, _ := time.Parse(fourteenDigitDateFormat, inputDate)
+	return fmt.Sprintf("%s", outputDate.Format("2006-01-02"))
+}
+
+// getRobustDates returns a simplified date format according to the
+// RobustLinks specification.
+//
+// TODO: Some of this code is repeated from getISODates. We should be
+// able to grab the dates early and then process without having to do
+// the regext work or checking twice.
+func getRobustDates(earliest string, latest string) (string, string) {
+
+	// Compile a regex to match just 14-digit numeric values.
+	regexPattern, _ := regexp.Compile("\\d{14}")
+
+	datetime := regexPattern.FindString(earliest)
+
+	if datetime == "" {
+		return "", ""
+	}
+
+	earliest = formatRobustDate(datetime)
+
+	// Latest date is implicit if there is an earliest.
+	latest = formatRobustDate(regexPattern.FindString(latest))
+
+	return earliest, latest
+}
+
+// makeReplacements will make the neccesary string replacements in our
+// robust links.
+func makeReplacements(html string, origin string, ia string, date string) string {
+
+	replaceDate := "{{ date }}"
+	replaceOrigin := "{{ origin }}"
+	replaceIA := "{{ ia }}"
+
+	html = strings.Replace(html, replaceDate, date, 1)
+	html = strings.Replace(html, replaceOrigin, origin, 1)
+	html = strings.Replace(html, replaceIA, ia, 1)
+
+	return html
+}
+
+// getRobust will return earliest and latest Robust links for the given
+// resource, which looks something like follows:
+//
+//		/*
+//			"RobustLinkEarliest": "
+//				<a href=\"http://web.archive.org/web/20020120142510/http://example.com/\"
+//				 data-originalurl=\"http://example.com/\"
+//				 data-versiondate=\"2002-01-20\">
+//				 HTTPreserve Robust Link - simply replace this text!</a>",
+//		*/
+//
+//	 NB. HTML fragment validator: https://appdevtools.com/html-validator
+func getRobust(origin string, earliest string, latest string) (string, string) {
+
+	earliestDate, latestDate := getRobustDates(earliest, latest)
+
+	if earliestDate == "" {
+		return "", ""
+	}
+
+	early := "<a href='{{ ia }}'" +
+		"\x20data-originalurl='{{ origin }}'" +
+		"\x20data-versiondate='{{ date }}'>" +
+		"HTTPreserve Robust Link - simply replace this text!!</a>"
+
+	late := "<a href='{{ ia }}'" +
+		"\x20data-originalurl='{{ origin }}'" +
+		"\x20data-versiondate='{{ date }}'>" +
+		"HTTPreserve Robust Link - simply replace this text!!</a>"
+
+	early = makeReplacements(early, origin, earliest, earliestDate)
+	late = makeReplacements(late, origin, latest, latestDate)
+
+	return early, late
+}
+
+func getRobustEncoded(origin string, earliest string, latest string) (string, string) {
+
+	earliestDate, latestDate := getRobustDates(earliest, latest)
+
+	if earliestDate == "" {
+		return "", ""
+	}
+
+	early := "&lt;a href='{{ ia }}'" +
+		"\x20data-originalurl='{{ origin }}'" +
+		"\x20data-versiondate='{{ date }}'&gt;" +
+		"HTTPreserve Robust Link - simply replace this text!!&lt;/a&gt;"
+
+	late := "&lt;a href='{{ ia }}'" +
+		"\x20data-originalurl='{{ origin }}'" +
+		"\x20data-versiondate='{{ date }}'&gt;" +
+		"HTTPreserve Robust Link - simply replace this text!!&lt;/a&gt;"
+
+	early = makeReplacements(early, origin, earliest, earliestDate)
+	late = makeReplacements(late, origin, latest, latestDate)
+
+	return early, late
+}

--- a/version.go
+++ b/version.go
@@ -6,7 +6,7 @@ const httpUSERAGENT = "exponentialDK-httpreserve/"
 
 // Version will return a simple version number for the app.
 func Version() string {
-	return "0.0.13"
+	return "0.0.14"
 }
 
 // VersionNumber is a synonym for Version()


### PR DESCRIPTION
Creates a snippet as follows:

```json
{
   "AnalysisVersionNumber": "0.0.13",
   "AnalysisVersionText": "exponentialDK-httpreserve/0.0.13",
   "SimpleRequestVersion": "httpreserve-simplerequest/0.0.4",
   "Link": "http://example.com/",
   "Title": "example domain",
   "ContentType": "text/html; charset=UTF-8",
   "ResponseCode": 206,
   "ResponseText": "Partial Content",
   "SourceURL": "http://example.com/",
   "ScreenShot": "snapshots are not currently enabled",
   "InternetArchiveLinkEarliest": "http://web.archive.org/web/20020120142510/http://example.com/",
   "InternetArchiveEarliestDate": "2002-01-20 14:25:10 +0000 UTC",
   "InternetArchiveLinkLatest": "http://web.archive.org/web/20230428043557/https://example.com/",
   "InternetArchiveLatestDate": "2023-04-28 04:35:57 +0000 UTC",
   "InternetArchiveSaveLink": "http://web.archive.org/save/http://example.com/",
   "InternetArchiveResponseCode": 302,
   "InternetArchiveResponseText": "Found",
   "RobustLinkEarliest": "\u003ca href=\"http://web.archive.org/web/20020120142510/http://example.com/\" data-originalurl=\"http://example.com/\" data-versiondate=\"2002-01-20\"\u003eHTTPreserve Robust Link - simply replace this text!!\u003c/a\u003e",
   "RobustLinkLatest": "\u003ca href=\"http://web.archive.org/web/20230428043557/https://example.com/\" data-originalurl=\"http://example.com/\" data-versiondate=\"2023-04-28\"\u003eHTTPreserve Robust Link - simply replace this text!!\u003c/a\u003e",
   "Archived": true,
   "Error": false,
   "ErrorMessage": "",
   "StatsCreationTime": "2.4732987s"
}
```

Does the HTML escaping cause us a significant problem? In the Web UI it's not as pretty as it could be, on the command line, JQ handles it and we get plain HTML. 

Connected to: https://github.com/httpreserve/httpreserve/issues/15